### PR TITLE
Pass dict instead of context to render() per Django 1.11

### DIFF
--- a/tabbed_admin/templatetags/tabbed_admin_tags.py
+++ b/tabbed_admin/templatetags/tabbed_admin_tags.py
@@ -37,13 +37,13 @@ def render_tab_fieldsets_inlines(context, entry):
             **entry['config']
         )
         context["fieldset"] = f
-        return render_to_string(template, context)
+        return render_to_string(template, context.flatten())
     elif entry['type'] == 'inline':
         try:
             inline_admin_formset = inline_matching[entry["name"]]
             context["inline_admin_formset"] = inline_admin_formset
             return render_to_string(inline_admin_formset.opts.template,
-                                    context)
+                                    context.flatten())
         except KeyError:  # The user does not have the permission
             pass
     return ''


### PR DESCRIPTION
Django 1.11 changed the way that context is passed into the templates:
https://docs.djangoproject.com/en/1.11/releases/1.11/#django-template-backends-django-template-render-prohibits-non-dict-context

So we're now flattening the context object into a dict with context.flattern()